### PR TITLE
Adjust M17 Address to 6 Bytes

### DIFF
--- a/binary_cps_format.md
+++ b/binary_cps_format.md
@@ -98,7 +98,7 @@ This structure is the beginning of the file. The fields are laid out in the foll
 
 | Field   | Data Type  | Description                                                                                                                                          |
 | ------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| address | uint8_t[8] | M17 address stored in 48 bits, following their [address encoding](https://spec.m17project.org/pdf/M17_spec.pdf#appendix.A)                           |
+| address | uint8_t[6] | M17 address stored in 48 bits, following their [address encoding](https://spec.m17project.org/pdf/M17_spec.pdf#appendix.A)                           |
 
 #### dmrContact_t type description
 


### PR DESCRIPTION
The M17 Address is encoded in 6 Bytes.
The diagram below is correct with 6 Bytes, but the text gives 8 Bytes as its size.